### PR TITLE
bug: Adding SSR adapter for netlify

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,8 @@
+import netlify from '@astrojs/netlify/functions';
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  output: 'server',
+  adapter: netlify()
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/netlify": "^1.0.0"
       },
       "devDependencies": {
-        "astro": "^1.0.1"
+        "astro": "^1.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -921,9 +921,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.2.tgz",
-      "integrity": "sha512-7Bmw8wGQnh/rRpybc6owYbAyr6SXKm7kX56gg82ABJbqnTQhbgOPtg8+k+KKkJekMU/gPe3LfMIh0+Ie+F9xUw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.3.tgz",
+      "integrity": "sha512-QaKFZIhraQaoWqg7s7wNCAuMI+r50UzmnlWhQAl7IMJ0RQ00IVwAi1sV7IMjf2h/iRT/b87xqN4aNlBDWf/qyg==",
       "dev": true,
       "dependencies": {
         "@astrojs/compiler": "^0.23.1",
@@ -6362,9 +6362,9 @@
       }
     },
     "astro": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.2.tgz",
-      "integrity": "sha512-7Bmw8wGQnh/rRpybc6owYbAyr6SXKm7kX56gg82ABJbqnTQhbgOPtg8+k+KKkJekMU/gPe3LfMIh0+Ie+F9xUw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-1.0.3.tgz",
+      "integrity": "sha512-QaKFZIhraQaoWqg7s7wNCAuMI+r50UzmnlWhQAl7IMJ0RQ00IVwAi1sV7IMjf2h/iRT/b87xqN4aNlBDWf/qyg==",
       "dev": true,
       "requires": {
         "@astrojs/compiler": "^0.23.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "astro": "astro"
   },
   "devDependencies": {
-    "astro": "^1.0.1"
+    "astro": "^1.0.3"
   },
   "dependencies": {
     "@astrojs/netlify": "^1.0.0"


### PR DESCRIPTION
## Summary

When a user adds the SSR components to their Astro site, the `404` logic doesn't work. Even with an applied redirect.

---
Production Site (still static and without the bug): https://prince-test-astro.netlify.app/beef
Deploy Preview Site (with the bug): https://deploy-preview-1--prince-test-astro.netlify.app/beef